### PR TITLE
Feature/file upload with type

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_and_types_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_and_types_actor.rb
@@ -26,6 +26,7 @@ module Hyrax
 
         def filter_file_types(input)
           file_types = {}
+          return file_types unless input.present?
           input.values.each do |val|
             if val.fetch('file_id', []).first
               file_types[val.fetch('file_id', []).first] = val.fetch('file_type', []).first

--- a/app/actors/hyrax/actors/create_with_files_and_types_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_and_types_actor.rb
@@ -2,14 +2,36 @@ module Hyrax
   module Actors
     class CreateWithFilesAndTypesActor < Hyrax::Actors::CreateWithFilesActor
       def create(env)
-        uploaded_file_types = filter_file_types(env.attributes.delete(:uploaded_file_types))
-        super
+        file_types = filter_file_types(env.attributes.delete(:uploaded_file_types))
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.create(env) && attach_files(files, file_types, env)
+      end
+
+      def update(env)
+        file_types = filter_file_types(env.attributes.delete(:uploaded_file_types))
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.update(env) && attach_files(files, file_types, env)
       end
 
       private 
+        # @return [TrueClass]
+        def attach_files(files, file_types, env)
+          return true if files.blank?
+          AttachFilesWithTypeToWorkJob.perform_later(env.curation_concern, files, file_types, env.attributes.to_h.symbolize_keys)
+          true
+        end
+
 
         def filter_file_types(input)
-          input.select {|_,v| v.present? }
+          file_types = {}
+          input.values.each do |val|
+            if val.fetch('file_id', []).first
+              file_types[val.fetch('file_id', []).first] = val.fetch('file_type', []).first
+            end
+          end
+          file_types.delete_if { |k, v| v.blank? }.with_indifferent_access
         end
 
     end

--- a/app/actors/hyrax/actors/create_with_files_and_types_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_and_types_actor.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  module Actors
+    class CreateWithFilesAndTypesActor < Hyrax::Actors::CreateWithFilesActor
+      def create(env)
+        uploaded_file_types = filter_file_types(env.attributes.delete(:uploaded_file_types))
+        super
+      end
+
+      private 
+
+        def filter_file_types(input)
+          input.select {|_,v| v.present? }
+        end
+
+    end
+  end
+end
+

--- a/app/assets/javascripts/data_paper_check_files.js
+++ b/app/assets/javascripts/data_paper_check_files.js
@@ -8,13 +8,19 @@ Blacklight.onLoad(function() {
 (function($){
 
   $.fn.check_file_requirement = function(option) {
-    return this.each(function() {
-      if ($('.related-files').find('.file_set_add_type').filter(function(){return this.value=='data paper'}).length > 0) {
-        $('#submit-required-files').attr('class', 'complete');
-      } else {
-        $('#submit-required-files').attr('class', 'incomplete');
-      }
-    })
+    check1 = false
+    if ($('.related-files').find('.file_set_add_type').filter(function(){return this.value=='data paper'}).length > 0) {
+      check1 = true
+    }
+    check2 = false
+    if ($('.files').find('.file_resource_type_select').filter(function(){return this.value=='data paper'}).length > 0) {
+      check2 = true
+    }
+    if (check1 === true || check2 === true) {
+      $('#submit-required-files').attr('class', 'complete');
+    } else {
+      $('#submit-required-files').attr('class', 'incomplete');
+    }
   }
 
 })(jQuery);

--- a/app/assets/javascripts/file_add_type.js
+++ b/app/assets/javascripts/file_add_type.js
@@ -1,15 +1,24 @@
 Blacklight.onLoad(function() {
   $('#fileupload').bind('fileuploadcompleted', function (e, data) {
-    var ele = $('#file_resource_type > select').clone().removeAttr('id');
-    $('.template-download').each(function() {
-      if ($(this).children('td').length < 5) {
-        var file_name = $(this).find(".name > input").val();
-        var input_name = "uploaded_file_types[" + file_name + "]";
-        ele.attr('name', input_name);
-        $td = $('<td/>').append(ele);
-        $(this).append($td);
-      }
-    });
+    window.setTimeout(add_type, 500);
   });
 });
 
+
+function add_type() {
+  $('.template-download').each(function(index) {
+    var ele = $('#file_resource_type > select').clone().removeAttr('id');
+    if ($(this).children('td').length < 5) {
+      var file_name = $(this).find(".name > input").val();
+      var input_name = "data_paper[uploaded_file_types][" + index + "][file_type][]";
+      ele.attr('name', input_name);
+      var ele2 = $('<input>').attr({
+        type: 'hidden',
+        name: "data_paper[uploaded_file_types][" + index + "][file_id][]"
+      })
+      ele2.val(file_name);
+      $td = $('<td/>').append(ele2).append(ele);
+      $(this).append($td);
+    }
+  });
+}

--- a/app/assets/javascripts/file_add_type.js
+++ b/app/assets/javascripts/file_add_type.js
@@ -1,0 +1,15 @@
+Blacklight.onLoad(function() {
+  $('#fileupload').bind('fileuploadcompleted', function (e, data) {
+    var ele = $('#file_resource_type > select').clone().removeAttr('id');
+    $('.template-download').each(function() {
+      if ($(this).children('td').length < 5) {
+        var file_name = $(this).find(".name > input").val();
+        var input_name = "uploaded_file_types[" + file_name + "]";
+        ele.attr('name', input_name);
+        $td = $('<td/>').append(ele);
+        $(this).append($td);
+      }
+    });
+  });
+});
+

--- a/app/assets/javascripts/file_add_type.js
+++ b/app/assets/javascripts/file_add_type.js
@@ -7,18 +7,23 @@ Blacklight.onLoad(function() {
 
 function add_type() {
   $('.template-download').each(function(index) {
+    var key = $('#file_resource_type').data('key')
     var ele = $('#file_resource_type > select').clone().removeAttr('id');
     if ($(this).children('td').length < 5) {
       var file_name = $(this).find(".name > input").val();
-      var input_name = "data_paper[uploaded_file_types][" + index + "][file_type][]";
+      var input_name = key + "[uploaded_file_types][" + index + "][file_type][]";
       ele.attr('name', input_name);
       var ele2 = $('<input>').attr({
         type: 'hidden',
-        name: "data_paper[uploaded_file_types][" + index + "][file_id][]"
+        name: key + "[uploaded_file_types][" + index + "][file_id][]"
       })
       ele2.val(file_name);
       $td = $('<td/>').append(ele2).append(ele);
       $(this).append($td);
     }
+  });
+  $('.file_resource_type_select').bind('change', function() {
+    $(this).check_file_requirement();
+    $('#data-paper-submit-requirements').check_submit_requirements();
   });
 }

--- a/app/controllers/hyrax/data_papers_controller.rb
+++ b/app/controllers/hyrax/data_papers_controller.rb
@@ -6,6 +6,9 @@ module Hyrax
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+
+    Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesAndTypesActor
+
     self.curation_concern_type = ::DataPaper
 
     # Use this line if you want to use a custom presenter

--- a/app/controllers/hyrax/data_papers_controller.rb
+++ b/app/controllers/hyrax/data_papers_controller.rb
@@ -7,7 +7,11 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
 
-    Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesAndTypesActor
+    begin
+      Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesAndTypesActor
+    rescue RuntimeError => e
+      Rails.logger.warn "Could not swap CreateWithFilesActor"
+    end
 
     self.curation_concern_type = ::DataPaper
 

--- a/app/controllers/hyrax/journals_controller.rb
+++ b/app/controllers/hyrax/journals_controller.rb
@@ -6,6 +6,13 @@ module Hyrax
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+
+    begin
+      Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::CreateWithFilesAndTypesActor
+    rescue RuntimeError => e
+      Rails.logger.warn "Could not swap CreateWithFilesActor"
+    end
+
     self.curation_concern_type = ::Journal
 
     # Use this line if you want to use a custom presenter

--- a/app/forms/hyrax/data_paper_form.rb
+++ b/app/forms/hyrax/data_paper_form.rb
@@ -101,7 +101,7 @@ module Hyrax
         permitted << { relation_attributes: permitted_relation_params }
         permitted << { license_nested_attributes: permitted_license_params }
         permitted << :journal_id
-        permitted << {uploaded_file_types: permitted_file_types}
+        permitted << { uploaded_file_types: permitted_file_types }
         permitted
       end
 

--- a/app/forms/hyrax/data_paper_form.rb
+++ b/app/forms/hyrax/data_paper_form.rb
@@ -85,6 +85,15 @@ module Hyrax
         ]
       end
 
+      def self.permitted_file_types
+        [
+          {
+            file_id: [],
+            file_type: []
+          }
+        ]
+      end
+
       def self.build_permitted_params
         permitted = super
         permitted << { creator_nested_attributes: permitted_creator_params }
@@ -92,6 +101,7 @@ module Hyrax
         permitted << { relation_attributes: permitted_relation_params }
         permitted << { license_nested_attributes: permitted_license_params }
         permitted << :journal_id
+        permitted << {uploaded_file_types: permitted_file_types}
         permitted
       end
 

--- a/app/forms/hyrax/journal_form.rb
+++ b/app/forms/hyrax/journal_form.rb
@@ -64,11 +64,21 @@ module Hyrax
         ]
       end
 
+      def self.permitted_file_types
+        [
+          {
+            file_id: [],
+            file_type: []
+          }
+        ]
+      end
+
       def self.build_permitted_params
         permitted = super
         permitted << { contact_attributes: permitted_contact_params }
         permitted << { date_attributes: permitted_date_params }
         permitted << { account_attributes: permitted_account_params }
+        permitted << { uploaded_file_types: permitted_file_types }
         permitted
       end
 

--- a/app/jobs/attach_files_with_type_to_work_job.rb
+++ b/app/jobs/attach_files_with_type_to_work_job.rb
@@ -1,0 +1,25 @@
+# Converts UploadedFiles into FileSets and attaches them to works.
+class AttachFilesWithTypeToWorkJob < AttachFilesToWorkJob
+
+  # @param [ActiveFedora::Base] work - the work object
+  # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
+  def perform(work, uploaded_files, file_types, **work_attributes)
+    validate_files!(uploaded_files)
+    user = User.find_by_user_key(work.depositor) # BUG? file depositor ignored
+    work_permissions = work.permissions.map(&:to_hash)
+    metadata = visibility_attributes(work_attributes)
+    uploaded_files.each do |uploaded_file|
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      actor.create_metadata(metadata)
+      if file_types.include?(uploaded_file.id.to_s)
+        actor.file_set.resource_type = Array.wrap(file_types.fetch(uploaded_file.id.to_s))
+      end
+      actor.create_content(uploaded_file)
+      actor.attach_to_work(work)
+      actor.file_set.permissions_attributes = work_permissions
+      uploaded_file.update(file_set_uri: actor.file_set.uri)
+    end
+  end
+
+end
+

--- a/app/views/hyrax/base/_file_items.html.erb
+++ b/app/views/hyrax/base/_file_items.html.erb
@@ -20,14 +20,16 @@
     </tbody>
   </table>
 <% end %>
-<div id="file_resource_type" class="hidden">
-  <%
-    if curation_concern.class == ::Journal
-      options = JournalFileTypesService.select_all_options
-    else
-      options = DataPaperFileTypesService.select_all_options
-    end
-  %>
+<%
+  if curation_concern.class == ::Journal
+    key = 'journal'
+    options = JournalFileTypesService.select_all_options
+  else
+    key = 'data_paper'
+    options = DataPaperFileTypesService.select_all_options
+  end
+%>
+<div id="file_resource_type" class="hidden" data-key="<%=key%>">
   <%= select_tag '#',
     options_for_select(options),
     prompt: 'Select type',

--- a/app/views/hyrax/base/_file_items.html.erb
+++ b/app/views/hyrax/base/_file_items.html.erb
@@ -1,4 +1,4 @@
-<h2>Set file type</h2>
+<h2>Manage files</h2>
 <div class="alert alert-success alert-dismissable" id="file_set_add_alert" role="alert" style="display: none;">
   <button type="button" class="close" aria-label="Close" 
     onclick="document.getElementById('file_set_add_alert').style.display='none';return false;">
@@ -6,7 +6,6 @@
   </button>
   <span class="message"></span>
 </div>
-<p>Recently uploaded files will only appear here after saving the record</p>
 <% if curation_concern.members.present? %>
   <table class="table table-striped related-files">
     <thead>
@@ -21,3 +20,18 @@
     </tbody>
   </table>
 <% end %>
+<div id="file_resource_type" class="hidden">
+  <%
+    if curation_concern.class == ::Journal
+      options = JournalFileTypesService.select_all_options
+    else
+      options = DataPaperFileTypesService.select_all_options
+    end
+  %>
+  <%= select_tag '#',
+    options_for_select(options),
+    prompt: 'Select type',
+    class: 'file_resource_type_select',
+    id: ''
+  %>
+</div>


### PR DESCRIPTION
I have modified the feature to add types to files.
 * On file upload, a select box appear for each file uploaded, allowing the user to select the type
 * When the user clicks on save or submit, the file type is added to the file set by the new actor 

For files already uploaded, the table with the files continue to be displayed below the file upload form. The files int his table may not immediately appear as the task of adding files to work is asynchronous.

The check for file of type _data paper_ is done as soon as the type is chosen in either location

This PR addresses #23 